### PR TITLE
Add YAML file for grid search, fixup in HTCondor shell script

### DIFF
--- a/vbfml/config/gridsearch/param_grid.yml
+++ b/vbfml/config/gridsearch/param_grid.yml
@@ -1,0 +1,9 @@
+# .yml file specifying the parameter grid for grid search
+param_grid:
+  n_layers_for_conv: [2, 3]
+  num_filters: [32]
+  kernel_size: [3]
+  n_layers_for_dense: [3]
+  num_nodes_for_dense: [200]
+  dropout: [0.]
+  learning_rate: [0.001, 0.01, 0.1]

--- a/vbfml/execute/htcondor_wrap.sh
+++ b/vbfml/execute/htcondor_wrap.sh
@@ -40,8 +40,7 @@ time ./train.py ${ARGS[@]}
 # Move the trained model directory back to the top directory
 # so that it gets transferred
 
-# mv output/model_* ${JOB_DIR}
-find -name 'model_v*' -type d | xargs -I {} mv {} ${JOB_DIR}
+find -name '*model_*' -type d | xargs -I {} mv {} ${JOB_DIR}
 cd ${JOB_DIR}
 echo "Directory content---"
 ls -lah .

--- a/vbfml/scripts/gridsearch
+++ b/vbfml/scripts/gridsearch
@@ -80,13 +80,6 @@ def get_gridsearch_directory(tag: str) -> str:
     help="Path to the .yml file that has the model configuration parameters.",
 )
 @click.option(
-    "-p",
-    "--param-grid",
-    default=vbfml_path("config/gridsearch/param_grid.yml"),
-    required=False,
-    help="Path to the .yml file that has the model configuration parameters.",
-)
-@click.option(
     "--frac-qcdv-events",
     default=1.0,
     required=False,
@@ -98,14 +91,12 @@ def cli(
     tag: str,
     input_dir: str,
     model_config: str,
-    param_grid: str,
     frac_qcdv_events: float,
 ):
     ctx.ensure_object(dict)
     ctx.obj["TAG"] = tag
     ctx.obj["INPUT_DIR"] = input_dir
     ctx.obj["MODEL_CONFIG"] = model_config
-    ctx.obj["PARAM_GRID"] = param_grid
     ctx.obj["FRAC_QCDV_EVENTS"] = frac_qcdv_events
 
 
@@ -138,13 +129,13 @@ def create_model(learning_rate: float, n_features: int, n_classes: int, dropout:
 
 
 def create_convolutional_model(
-    n_layers_for_conv: int=3,
-    num_filters: int=32,
-    kernel_size: int=3,
-    n_layers_for_dense: int=3,
-    num_nodes_for_dense: int=200,
-    dropout: float=0.,
-    learning_rate: float=1e-3,
+    n_layers_for_conv: int = 3,
+    num_filters: int = 32,
+    kernel_size: int = 3,
+    n_layers_for_dense: int = 3,
+    num_nodes_for_dense: int = 200,
+    dropout: float = 0.0,
+    learning_rate: float = 1e-3,
 ):
     model = sequential_convolutional_model(
         n_layers_for_conv=n_layers_for_conv,
@@ -186,6 +177,13 @@ def create_convolutional_model(
     help="Number of iterations through the whole training set.",
 )
 @click.option(
+    "-p",
+    "--param-grid",
+    default=vbfml_path("config/gridsearch/param_grid.yml"),
+    required=False,
+    help="Path to the .yml file that has the model configuration parameters.",
+)
+@click.option(
     "--dryrun",
     is_flag=True,
     help="Dry run flag, will create the files but won't submit anything.",
@@ -204,6 +202,7 @@ def create_convolutional_model(
 def search(
     ctx,
     num_epochs: int,
+    param_grid: str,
     dryrun: bool,
     test: bool,
     overwrite: bool,
@@ -232,18 +231,17 @@ def search(
     )
 
     # Load the parameter grid for grid search from the .yml file
-    param_grid_file = ctx.obj["PARAM_GRID"]
-    loader = YamlLoader(param_grid_file)
+    loader = YamlLoader(param_grid)
     branch = "param_grid"
     try:
-        param_grid = loader.load()[branch]
+        grid = loader.load()[branch]
     except KeyError:
         raise RuntimeError(
             f'In {param_grid_file}, please specify grid parameters under "{branch}" branch'
         )
 
     # Get all possible parameter combinations
-    keys, values = zip(*param_grid.items())
+    keys, values = zip(*grid.items())
     combinations = [dict(zip(keys, v)) for v in itertools.product(*values)]
 
     models = {}

--- a/vbfml/scripts/gridsearch
+++ b/vbfml/scripts/gridsearch
@@ -37,6 +37,7 @@ from vbfml.training.util import (
 from vbfml.util import (
     ModelConfiguration,
     ModelFactory,
+    YamlLoader,
     vbfml_path,
     git_rev_parse,
     git_diff,
@@ -65,14 +66,23 @@ def get_gridsearch_directory(tag: str) -> str:
     help="A string-valued tag used to identify the run. If a run with this tag exists, will use existing run.",
 )
 @click.option(
+    "-i",
     "--input-dir",
     default=vbfml_path("root/2021-11-13_vbfhinv_treesForML"),
     required=False,
     help="Input directory containing the ROOT files for training and validation.",
 )
 @click.option(
+    "-m",
     "--model-config",
     default=vbfml_path("config/convolutional_model.yml"),
+    required=False,
+    help="Path to the .yml file that has the model configuration parameters.",
+)
+@click.option(
+    "-p",
+    "--param-grid",
+    default=vbfml_path("config/gridsearch/param_grid.yml"),
     required=False,
     help="Path to the .yml file that has the model configuration parameters.",
 )
@@ -83,11 +93,19 @@ def get_gridsearch_directory(tag: str) -> str:
     help="Fraction of the QCD V events to use.",
 )
 @click.pass_context
-def cli(ctx, tag: str, input_dir: str, model_config: str, frac_qcdv_events: float):
+def cli(
+    ctx,
+    tag: str,
+    input_dir: str,
+    model_config: str,
+    param_grid: str,
+    frac_qcdv_events: float,
+):
     ctx.ensure_object(dict)
     ctx.obj["TAG"] = tag
     ctx.obj["INPUT_DIR"] = input_dir
     ctx.obj["MODEL_CONFIG"] = model_config
+    ctx.obj["PARAM_GRID"] = param_grid
     ctx.obj["FRAC_QCDV_EVENTS"] = frac_qcdv_events
 
 
@@ -120,12 +138,13 @@ def create_model(learning_rate: float, n_features: int, n_classes: int, dropout:
 
 
 def create_convolutional_model(
-    n_layers_for_conv: int,
-    num_filters: int,
-    kernel_size: int,
-    n_layers_for_dense: int,
-    num_nodes_for_dense: int,
-    dropout: float,
+    n_layers_for_conv: int=3,
+    num_filters: int=32,
+    kernel_size: int=3,
+    n_layers_for_dense: int=3,
+    num_nodes_for_dense: int=200,
+    dropout: float=0.,
+    learning_rate: float=1e-3,
 ):
     model = sequential_convolutional_model(
         n_layers_for_conv=n_layers_for_conv,
@@ -140,7 +159,7 @@ def create_convolutional_model(
     )
 
     optimizer = tf.keras.optimizers.Adam(
-        # learning_rate=learning_rate,
+        learning_rate=learning_rate,
         beta_1=0.9,
         beta_2=0.999,
         epsilon=1e-07,
@@ -212,14 +231,16 @@ def search(
         frac_qcdv_events=ctx.obj["FRAC_QCDV_EVENTS"],
     )
 
-    param_grid = {
-        "n_layers_for_conv": [2, 3],
-        "num_filters": [32, 64],
-        "kernel_size": [3],
-        "n_layers_for_dense": [3],
-        "num_nodes_for_dense": [200, 300],
-        "dropout": [0.2, 0.4],
-    }
+    # Load the parameter grid for grid search from the .yml file
+    param_grid_file = ctx.obj["PARAM_GRID"]
+    loader = YamlLoader(param_grid_file)
+    branch = "param_grid"
+    try:
+        param_grid = loader.load()[branch]
+    except KeyError:
+        raise RuntimeError(
+            f'In {param_grid_file}, please specify grid parameters under "{branch}" branch'
+        )
 
     # Get all possible parameter combinations
     keys, values = zip(*param_grid.items())


### PR DESCRIPTION
This PR introduces the following changes:
- The parameter grid will be read from a .yml file in the `gridsearch` script, instead of hard-coding. The path to the yml file can be specified via `-p`.
- Bug fix in HTCondor shell script