### PR TITLE
Fixup in model configuration test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning

--- a/vbfml/tests/test_model_configuration.py
+++ b/vbfml/tests/test_model_configuration.py
@@ -1,6 +1,6 @@
 import os
 from unittest import TestCase
-from vbfml.util import vbfml_path, ModelConfiguration
+from vbfml.util import vbfml_path, ModelConfiguration, YamlLoader
 
 pjoin = os.path.join
 
@@ -41,3 +41,19 @@ class TestConfigParser(TestCase):
         for mconfig in self.mconfigs:
             for key, type in self.features_to_check.items():
                 self.assertIsInstance(mconfig.get(key), type)
+
+
+class ParamGridParser(TestCase):
+    def setUp(self) -> None:
+        grid_search_dir = vbfml_path("config/gridsearch")
+        grid_file = pjoin(grid_search_dir, os.listdir(grid_search_dir)[0])
+
+        loader = YamlLoader(grid_file)
+        self.grid = loader.load()
+
+    def test_grid_branch(self):
+        keys = list(self.grid.keys())
+        # Has to be one branch in this file
+        self.assertEqual(len(keys), 1)
+        # And it has to be named as "param_grid"
+        self.assertEqual(keys[0], "param_grid")

--- a/vbfml/tests/test_model_configuration.py
+++ b/vbfml/tests/test_model_configuration.py
@@ -57,3 +57,10 @@ class ParamGridParser(TestCase):
         self.assertEqual(len(keys), 1)
         # And it has to be named as "param_grid"
         self.assertEqual(keys[0], "param_grid")
+
+    def test_branch_types(self):
+        keys = list(self.grid.keys())
+        param_grid = self.grid[keys[0]]
+        # Each branch must be a list
+        for k, v in param_grid.items():
+            self.assertIsInstance(v, list)

--- a/vbfml/tests/test_model_configuration.py
+++ b/vbfml/tests/test_model_configuration.py
@@ -11,7 +11,9 @@ class TestConfigParser(TestCase):
         config_dir = vbfml_path("config")
 
         # We'll test each configuration file
-        config_files = [pjoin(config_dir, f) for f in os.listdir(config_dir)]
+        config_files = [
+            pjoin(config_dir, f) for f in os.listdir(config_dir) if f.endswith(".yml")
+        ]
         for cf in config_files:
             self.mconfigs.append(ModelConfiguration(cf))
 


### PR DESCRIPTION
This is a simple fix to model config related unit tests, so that the test script would skip recently included `gridsearch` sub-directory under `config`.