### PR TITLE
MLsubmit fix

### DIFF
--- a/vbfml/execute/htcondor_wrap.sh
+++ b/vbfml/execute/htcondor_wrap.sh
@@ -36,13 +36,4 @@ echo "===================="
 echo "Setup done: $(date)"
 echo "Executing: ./train.py ${ARGS[@]}"
 time ./train.py ${ARGS[@]}
-
-# Move the trained model directory back to the top directory
-# so that it gets transferred
-
-find -name '*model_*' -type d | xargs -I {} mv {} ${JOB_DIR}
-cd ${JOB_DIR}
-echo "Directory content---"
-ls -lah .
-echo "===================="
 echo "Run done: $(date)"

--- a/vbfml/execute/mlsubmit
+++ b/vbfml/execute/mlsubmit
@@ -136,10 +136,6 @@ def do_submit(args):
     if not os.path.exists(filedir):
         os.makedirs(filedir)
 
-    # Output path to transfer to local machine: The trained model
-    training_dir_name = os.path.basename(subdir.rstrip("/"))
-    output_paths = [training_dir_name]
-
     # Arguments to the shell script
     arguments = [
         f"--training-directory {os.path.abspath(subdir)}",
@@ -155,7 +151,6 @@ def do_submit(args):
         "should_transfer_files": "YES",
         "when_to_transfer_output": "ON_EXIT",
         "transfer_input_files": ", ".join(input_files),
-        "transfer_output_files": ", ".join(output_paths),
         "Output": pjoin(filedir, "out.txt"),
         "Error": pjoin(filedir, "err.txt"),
         "log": pjoin(filedir, "log.txt"),


### PR DESCRIPTION
This PR removes the unnecessary `transfer_output_files` argument in the HTCondor submission script.