### PR TITLE
Fix the seed of weight initializers for all layers in convnet

### DIFF
--- a/vbfml/models.py
+++ b/vbfml/models.py
@@ -8,6 +8,7 @@ from tensorflow.keras.layers import (
     Flatten,
 )
 
+from tensorflow.keras.initializers import GlorotUniform
 from tensorflow.keras.models import Sequential
 from tensorflow.keras import regularizers
 
@@ -99,6 +100,9 @@ def sequential_convolutional_model(
     num_pixels = np.prod(image_shape)
     model.add(Reshape(image_shape, input_shape=(num_pixels,)))
 
+    # Weight initalizer, fix the seed
+    initializer = GlorotUniform(seed=42)
+
     for ilayer in range(n_layers_for_conv):
         # We'll use conv+conv+pool architecture
         # Two convolutional layers followed by one max pooling layer
@@ -107,6 +111,7 @@ def sequential_convolutional_model(
                 n_filters_for_conv[ilayer],
                 filter_size_for_conv[ilayer],
                 padding="same",
+                kernel_initializer=initializer,
             )
         )
         model.add(
@@ -114,6 +119,7 @@ def sequential_convolutional_model(
                 n_filters_for_conv[ilayer],
                 filter_size_for_conv[ilayer],
                 padding="same",
+                kernel_initializer=initializer,
             )
         )
 
@@ -128,10 +134,11 @@ def sequential_convolutional_model(
             Dense(
                 n_nodes_for_dense[ilayer],
                 activation="relu",
+                kernel_initializer=initializer,
             )
         )
         if dropout:
             model.add(Dropout(rate=dropout))
 
-    model.add(Dense(n_classes, activation="softmax"))
+    model.add(Dense(n_classes, kernel_initializer=initializer, activation="softmax"))
     return model


### PR DESCRIPTION
For better re-producability between different runs, fix the seed of the weight initializer.

Note that `GlorotUniform` is already the default initializer used by Keras, we're just fixing the seed of it here. @pmayenco please note and let me know if you want any changes here. I did a quick test by running this over a small subset of samples and it doesn't seem to hinder training performance.