### PR TITLE
Update default settings, do not fix the weight initialization seed

### DIFF
--- a/vbfml/config/convolutional_model.yml
+++ b/vbfml/config/convolutional_model.yml
@@ -1,6 +1,6 @@
 architecture: conv
 training_parameters:
-  batch_size: 10
+  batch_size: 100
   batch_buffer_size: 1000
   scale_features: norm
   shuffle: true

--- a/vbfml/config/convolutional_model.yml
+++ b/vbfml/config/convolutional_model.yml
@@ -14,10 +14,10 @@ weight_expression: weight_total*xs/sumw
 features:
 - JetImage_pixels
 arch_parameters:
-  n_layers_for_conv: 3 
-  n_filters_for_conv: [32,32,32]
-  filter_size_for_conv: [3,3,3]
-  pool_size_for_conv: [2,2,2]
+  n_layers_for_conv: 2 
+  n_filters_for_conv: [32,32]
+  filter_size_for_conv: [3,3]
+  pool_size_for_conv: [2,2]
   n_layers_for_dense: 3
   n_nodes_for_dense: [200,200,200]
   image_shape: [40, 20, 1]

--- a/vbfml/models.py
+++ b/vbfml/models.py
@@ -8,7 +8,6 @@ from tensorflow.keras.layers import (
     Flatten,
 )
 
-from tensorflow.keras.initializers import GlorotUniform
 from tensorflow.keras.models import Sequential
 from tensorflow.keras import regularizers
 
@@ -100,9 +99,6 @@ def sequential_convolutional_model(
     num_pixels = np.prod(image_shape)
     model.add(Reshape(image_shape, input_shape=(num_pixels,)))
 
-    # Weight initalizer, fix the seed
-    initializer = GlorotUniform(seed=42)
-
     for ilayer in range(n_layers_for_conv):
         # We'll use conv+conv+pool architecture
         # Two convolutional layers followed by one max pooling layer
@@ -111,7 +107,6 @@ def sequential_convolutional_model(
                 n_filters_for_conv[ilayer],
                 filter_size_for_conv[ilayer],
                 padding="same",
-                kernel_initializer=initializer,
             )
         )
         model.add(
@@ -119,7 +114,6 @@ def sequential_convolutional_model(
                 n_filters_for_conv[ilayer],
                 filter_size_for_conv[ilayer],
                 padding="same",
-                kernel_initializer=initializer,
             )
         )
 
@@ -134,11 +128,10 @@ def sequential_convolutional_model(
             Dense(
                 n_nodes_for_dense[ilayer],
                 activation="relu",
-                kernel_initializer=initializer,
             )
         )
         if dropout:
             model.add(Dropout(rate=dropout))
 
-    model.add(Dense(n_classes, kernel_initializer=initializer, activation="softmax"))
+    model.add(Dense(n_classes, activation="softmax"))
     return model

--- a/vbfml/training/plot.py
+++ b/vbfml/training/plot.py
@@ -617,8 +617,12 @@ class ImagePlotter:
         image = self._reshape(image)
 
         fig, ax = plt.subplots()
-        eta_edges = np.linspace(self.eta_range[0], self.eta_range[1], self.n_eta_bins+1)
-        phi_edges = np.linspace(self.phi_range[0], self.phi_range[1], self.n_phi_bins+1)
+        eta_edges = np.linspace(
+            self.eta_range[0], self.eta_range[1], self.n_eta_bins + 1
+        )
+        phi_edges = np.linspace(
+            self.phi_range[0], self.phi_range[1], self.n_phi_bins + 1
+        )
 
         cmap = ax.pcolormesh(
             eta_edges, phi_edges, image.T, norm=matplotlib.colors.LogNorm(vmin, vmax)


### PR DESCRIPTION
This PR undoes the weight initialization seed fixing in PR #30, and also updates the default convolutional network model and batch size. 

@pmayenco please note, once we decide on a reasonable set of parameters (e.g. dropout), we can merge the final version of things into `main` so that we don't have to change settings by hand each time. Also let me know if you feel like more changes are needed, thanks!