### PR TITLE
Require protobuf<4.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
             python3 -m pip install tensorflow==2.5.0
             python3 -m pip install scikit-learn==0.24.2
             python3 -m pip install awkward==1.0.2
-            python3 -m pip install protobuf<4.0.0
+            python3 -m pip install 'protobuf<4.0.0'
             python3 -m pytest
         
         - name: Set environment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
             python3 -m pip install tensorflow==2.5.0
             python3 -m pip install scikit-learn==0.24.2
             python3 -m pip install awkward==1.0.2
+            python3 -m pip install protobuf<4.0.0
             python3 -m pytest
         
         - name: Set environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyyaml
 gitpython
 uproot>=4.1.1
 typing-extensions==4.1.1
+protobuf<4.0.0


### PR DESCRIPTION
This PR provides a fix to the issue where `tensorflow` crashes because of a recently released version of `protobuf`. We solve this problem by requiring the `protobuf` package version to be `<4.0.0`. @pmayenco, this should hopefully solve the issue you were seeing earlier. 